### PR TITLE
Updated to accept another parameter for certname. What this allows is…

### DIFF
--- a/manifests/darwin.pp
+++ b/manifests/darwin.pp
@@ -4,6 +4,7 @@ class pe_client_tools_easy_setup::darwin (
     String $pe_server_certname = 'master',
     String $access_token_path  = '~/.puppetlabs/token',
     String $client_tools_package_path  = '/tmp/pe-client-tools.dmg',
+    String $certname = 'ca.pem',
 ){
 
   file { '/etc/puppetlabs/puppet/ssl/certs':
@@ -16,11 +17,11 @@ class pe_client_tools_easy_setup::darwin (
 
   exec { 'create ca.pem file':
     command => "/usr/bin/curl -k -o /etc/puppetlabs/puppet/ssl/certs/ca.pem https://${pe_server_certname}:8140/puppet-ca/v1/certificate/ca",
-    creates => '/etc/puppetlabs/puppet/ssl/certs/ca.pem',
+    creates => "/etc/puppetlabs/puppet/ssl/certs/${certname}",
     require => File['/etc/puppetlabs/puppet/ssl/certs'],
   }
 
-  file { '/etc/puppetlabs/puppet/ssl/certs/ca.pem':
+  file { "/etc/puppetlabs/puppet/ssl/certs/${certname}":
     ensure  => file,
     mode    => '0444',
     require => Exec['create ca.pem file'],
@@ -28,22 +29,22 @@ class pe_client_tools_easy_setup::darwin (
 
   file { '/etc/puppetlabs/client-tools/orchestrator.conf':
     ensure  => file,
-    content => epp('pe_client_tools_easy_setup/orchestrator.conf.epp', {'pe_server_certname'=> $pe_server_certname, 'access_token_path' => $access_token_path}),
+    content => epp('pe_client_tools_easy_setup/orchestrator.conf.epp', {'pe_server_certname'=> $pe_server_certname, 'access_token_path' => $access_token_path, 'certname' => $certname}),
   }
 
   file { '/etc/puppetlabs/client-tools/puppet-access.conf':
     ensure  => file,
-    content => epp('pe_client_tools_easy_setup/puppet-access.conf.epp', {'pe_server_certname'=> $pe_server_certname, 'access_token_path' => $access_token_path}),
+    content => epp('pe_client_tools_easy_setup/puppet-access.conf.epp', {'pe_server_certname'=> $pe_server_certname, 'access_token_path' => $access_token_path, 'certname' => $certname}),
   }
 
   file { '/etc/puppetlabs/client-tools/puppet-code.conf':
     ensure  => file,
-    content => epp('pe_client_tools_easy_setup/puppet-code.conf.epp', {'pe_server_certname'=> $pe_server_certname, 'access_token_path' => $access_token_path}),
+    content => epp('pe_client_tools_easy_setup/puppet-code.conf.epp', {'pe_server_certname'=> $pe_server_certname, 'access_token_path' => $access_token_path, 'certname' => $certname}),
   }
 
   file { '/etc/puppetlabs/client-tools/puppetdb.conf':
     ensure  => file,
-    content => epp('pe_client_tools_easy_setup/puppetdb.conf.epp', {'pe_server_certname'=> $pe_server_certname, 'access_token_path' => $access_token_path}),
+    content => epp('pe_client_tools_easy_setup/puppetdb.conf.epp', {'pe_server_certname'=> $pe_server_certname, 'access_token_path' => $access_token_path, 'certname' => $certname}),
   }
 
   file { $client_tools_package_path: }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -34,6 +34,7 @@ class pe_client_tools_easy_setup (
     String $client_tools_package_path,
     String $pe_server_certname = 'master',
     String $access_token_path  = '~/.puppetlabs/token',
+    String $certname = 'ca.pem',
 ){
 
   case $::kernel {
@@ -42,6 +43,7 @@ class pe_client_tools_easy_setup (
         client_tools_package_path => $client_tools_package_path,
         pe_server_certname        => $pe_server_certname,
         access_token_path         => $access_token_path,
+        certname                  => $certname,
       }
     }
     'Linux': {
@@ -49,6 +51,7 @@ class pe_client_tools_easy_setup (
         client_tools_package_path => $client_tools_package_path,
         pe_server_certname        => $pe_server_certname,
         access_token_path         => $access_token_path,
+        certname                  => $certname,
       }
     }
     'Darwin': {
@@ -56,6 +59,7 @@ class pe_client_tools_easy_setup (
         client_tools_package_path => $client_tools_package_path,
         pe_server_certname        => $pe_server_certname,
         access_token_path         => $access_token_path,
+        certname                  => $certname,
       }
     }
     default: {
@@ -63,6 +67,7 @@ class pe_client_tools_easy_setup (
         client_tools_package_path => $client_tools_package_path,
         pe_server_certname        => $pe_server_certname,
         access_token_path         => $access_token_path,
+        certname                  => $certname,
       }
     }
   }

--- a/manifests/linux.pp
+++ b/manifests/linux.pp
@@ -4,6 +4,7 @@ class pe_client_tools_easy_setup::linux  (
     String $pe_server_certname = 'master',
     String $access_token_path  = '~/.puppetlabs/token',
     String $client_tools_package_path  = '/tmp/pe-client-tools.rpm',
+    String $certname = 'ca.pem',
 ){
 
   file { '/etc/puppetlabs/puppet/ssl/certs':
@@ -16,11 +17,11 @@ class pe_client_tools_easy_setup::linux  (
 
   exec { 'create ca.pem file':
     command => "/usr/bin/curl -k -o /etc/puppetlabs/puppet/ssl/certs/ca.pem https://${pe_server_certname}:8140/puppet-ca/v1/certificate/ca",
-    creates => '/etc/puppetlabs/puppet/ssl/certs/ca.pem',
+    creates => '/etc/puppetlabs/puppet/ssl/certs/${certname}',
     require => File['/etc/puppetlabs/puppet/ssl/certs'],
   }
 
-  file { '/etc/puppetlabs/puppet/ssl/certs/ca.pem':
+  file { "/etc/puppetlabs/puppet/ssl/certs/${certname}":
     ensure  => file,
     mode    => '0444',
     require => Exec['create ca.pem file'],
@@ -29,22 +30,22 @@ class pe_client_tools_easy_setup::linux  (
   file { '/etc/puppetlabs/client-tools/orchestrator.conf':
     ensure  => file,
     content => epp('pe_client_tools_easy_setup/orchestrator.conf.epp',
-                  {'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}),
+                  {'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}, 'certname' => $certname),
   }
 
   file { '/etc/puppetlabs/client-tools/puppet-access.conf':
     ensure  => file,
-    content => epp('pe_client_tools_easy_setup/puppet-access.conf.epp', {'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}),
+    content => epp('pe_client_tools_easy_setup/puppet-access.conf.epp', {'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}, 'certname' => $certname),
   }
 
   file { '/etc/puppetlabs/client-tools/puppet-code.conf':
     ensure  => file,
-    content => epp('pe_client_tools_easy_setup/puppet-code.conf.epp', {'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}),
+    content => epp('pe_client_tools_easy_setup/puppet-code.conf.epp', {'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}, 'certname' => $certname),
   }
 
   file { '/etc/puppetlabs/client-tools/puppetdb.conf':
     ensure  => file,
-    content => epp('pe_client_tools_easy_setup/puppetdb.conf.epp', {'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}),
+    content => epp('pe_client_tools_easy_setup/puppetdb.conf.epp', {'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}, 'certname' => $certname),
   }
 
   file { $client_tools_package_path: }

--- a/manifests/windows.pp
+++ b/manifests/windows.pp
@@ -4,6 +4,7 @@ class pe_client_tools_easy_setup::windows  (
     String $pe_server_certname = 'master',
     String $access_token_path  = '~/.puppetlabs/token',
     String $client_tools_package_path  = 'C:\\Windows\\Temp\\pe-client-tools.msi',
+    String $certname = 'ca.pem',
 ){
 
     file { 'C:\\ProgramData\\PuppetLabs\\puppet\\etc\\ssl\\certs':
@@ -34,22 +35,22 @@ class pe_client_tools_easy_setup::windows  (
 
     file { 'C:\\ProgramData\\PuppetLabs\\client-tools\\orchestrator.conf':
       ensure  => file,
-      content => epp('pe_client_tools_easy_setup/orchestrator.conf.epp',{'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}),
+      content => epp('pe_client_tools_easy_setup/orchestrator.conf.epp',{'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}, 'certname' => $certname),
     }
 
     file { 'C:\\ProgramData\\PuppetLabs\\client-tools\\puppet-access.conf':
       ensure  => file,
-      content => epp('pe_client_tools_easy_setup/puppet-access.conf.epp',{'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}),
+      content => epp('pe_client_tools_easy_setup/puppet-access.conf.epp',{'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}, 'certname' => $certname),
     }
 
     file { 'C:\\ProgramData\\PuppetLabs\\client-tools\\puppet-code.conf':
       ensure  => file,
-      content => epp('pe_client_tools_easy_setup/puppet-code.conf.epp',{'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}),
+      content => epp('pe_client_tools_easy_setup/puppet-code.conf.epp',{'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}, 'certname' => $certname),
     }
 
     file { 'C:\\ProgramData\\PuppetLabs\\client-tools\\puppetdb.conf':
       ensure  => file,
-      content => epp('pe_client_tools_easy_setup/puppetdb.conf.epp',{'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}),
+      content => epp('pe_client_tools_easy_setup/puppetdb.conf.epp',{'pe_server_certname' => $pe_server_certname, 'access_token_path' => $access_token_path}, 'certname' => $certname),
     }
 
     file { $client_tools_package_path: }

--- a/templates/orchestrator.conf.epp
+++ b/templates/orchestrator.conf.epp
@@ -3,9 +3,9 @@
         "service-url": "https://<%= $pe_server_certname %>:8143",
         "environment": "production",
         <% if $kernel == 'windows' { -%>
-        "cacert": "C:\\ProgramData\\PuppetLabs\\puppet\\etc\\ssl\\certs\\ca.pem",
+        "cacert": "C:\\ProgramData\\PuppetLabs\\puppet\\etc\\ssl\\certs\\<%= $certname %>",
         <% } else { -%>
-        "cacert": "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
+        "cacert": "/etc/puppetlabs/puppet/ssl/certs/<%= $certname %>",
         <% } -%>
         "token-file": "<%= $access_token_path %>",
         "color": true,

--- a/templates/puppet-access.conf.epp
+++ b/templates/puppet-access.conf.epp
@@ -1,8 +1,8 @@
 {
     "service-url": "https://<%= $pe_server_certname %>:4433/rbac-api",
     <% if $kernel == 'windows' { -%>
-    "certificate-file": "C:\\ProgramData\\PuppetLabs\\puppet\\etc\\ssl\\certs\\ca.pem"
+    "certificate-file": "C:\\ProgramData\\PuppetLabs\\puppet\\etc\\ssl\\certs\\<%= $certname %>"
     <% } else { -%>
-    "certificate-file": "/etc/puppetlabs/puppet/ssl/certs/ca.pem"
+    "certificate-file": "/etc/puppetlabs/puppet/ssl/certs/<%= $certname %>"
     <% } -%>
 }

--- a/templates/puppet-code.conf.epp
+++ b/templates/puppet-code.conf.epp
@@ -1,9 +1,9 @@
 {
     "service-url": "https://<%= $pe_server_certname %>:8170/code-manager",
     <% if $kernel == 'windows' { -%>
-    "cacert": "C:\\ProgramData\\PuppetLabs\\puppet\\etc\\ssl\\certs\\ca.pem",
+    "cacert": "C:\\ProgramData\\PuppetLabs\\puppet\\etc\\ssl\\certs\\<%= $certname %>",
     <% } else { -%>
-    "cacert": "/etc/puppetlabs/puppet/ssl/certs/ca.pem",
+    "cacert": "/etc/puppetlabs/puppet/ssl/certs/<%= $certname %>",
     <% } -%>
     "token-file": "<%= $access_token_path %>"
 }

--- a/templates/puppetdb.conf.epp
+++ b/templates/puppetdb.conf.epp
@@ -2,9 +2,9 @@
     "puppetdb": {
         "server_urls": "https://<%= $pe_server_certname %>:8081",
         <% if $kernel == 'windows' { -%>
-        "cacert": "C:\\ProgramData\\PuppetLabs\\puppet\\etc\\ssl\\certs\\ca.pem"
+        "cacert": "C:\\ProgramData\\PuppetLabs\\puppet\\etc\\ssl\\certs\\<%= $certname %>"
         <% } else { -%>
-        "cacert": "/etc/puppetlabs/puppet/ssl/certs/ca.pem"
+        "cacert": "/etc/puppetlabs/puppet/ssl/certs/<%= $certname %>"
         <% } -%>
     }
 }


### PR DESCRIPTION
… the user to have a machine that is maybe being managed by another Puppet master, but still can access a different one. Added the $certname parameter and updated the templates accordingly.
---
This PR specifically adds in the certname parameter so it will preserve machines with an already existing ca.pem at /etc/puppetlabs/puppet/ssl/certs/

For example, my workstation may be being managed by a separate Puppet Master than the one I want to hook client tools into.

Changes the apply command to 'puppet apply -e "class { 'pe_client_tools_easy_setup': pe_server_certname => 'master.inf.puppet.vm', client_tools_package_path => '/Downloads/pe-client-tools-16.5.2-1.osx10.11.dmg', certname => 'ca.master.pem'}" --modulepath /etc/puppetlabs/code/environments/production/modules/'